### PR TITLE
Rewrite exception logging

### DIFF
--- a/+mlog/LogHandler.m
+++ b/+mlog/LogHandler.m
@@ -1,7 +1,7 @@
 classdef (Abstract) LogHandler < handle
     %LOGHANDLER Summary of this class goes here
     %   Detailed explanation goes here
-  
+
     properties
         level
         dateFormat
@@ -18,7 +18,7 @@ classdef (Abstract) LogHandler < handle
     properties (Dependent)
         format
     end
-  
+
     methods
         function obj = LogHandler(options)
             arguments
@@ -55,7 +55,7 @@ classdef (Abstract) LogHandler < handle
 
             [tokens, tokenExtents] = regexp(...
                 formatStr, "%\((\w+)\)", 'tokens', 'tokenExtents');
-          
+
             matlabFmt = formatStr;
             for extents = tokenExtents(end:-1:1)
                 ext = extents{1};

--- a/+mlog/LogRecord.m
+++ b/+mlog/LogRecord.m
@@ -1,7 +1,7 @@
 classdef LogRecord < handle
     %LogRecord Summary of this class goes here
     %   Detailed explanation goes here
-  
+
     properties
         logger
     end
@@ -30,7 +30,7 @@ classdef LogRecord < handle
         name
         process
     end
-  
+
     methods
         function obj = LogRecord(logger, level, msg, varargin)
             %LogRecord Construct an instance of this class f
@@ -49,7 +49,7 @@ classdef LogRecord < handle
             obj.args = varargin;
             obj.time = datetime("now");
         end
-      
+
         function res = asctime(obj)
             res = obj.time;
         end
@@ -133,7 +133,7 @@ classdef LogRecord < handle
                 iEntry = find(inModule, 1, 'last');
                 res = stack(iEntry + 1:end);
                 obj.callerStack_ = res;
-            end          
+            end
         end
     end
 end

--- a/+mlog/Logger.m
+++ b/+mlog/Logger.m
@@ -113,21 +113,25 @@ classdef Logger < handle
             obj.addmsg(mlog.LogLevel.FATAL, msg, varargin{:});
         end
         %%
-        function log_exception(obj, exc)
+        function exception(obj, exc, msg, options)
+            % EXCEPTION log the message as an ERROR with the traceback.
             arguments
                 obj
-                exc MException
+                exc (1,1) MException
+                msg (1,1) string = ""
+                options.splitlines (1,1) logical = false
             end
-            obj.error(sprintf('Exception %s - %s', exc.identifier, exc.message));
-            for s = exc.stack'
-                [~, base, ext] = fileparts(s.file);
-                obj.error(sprintf('  Error in %s: %s (line %d)', [base, ext], s.name, s.line));
-            end
-            if ~isempty(exc.cause)
-                obj.error('Cause:');
-                for c = exc.cause'
-                    obj.error(sprintf('  %s', c));
+            traceback = string(exc.getReport());
+            lines = [msg; "Traceback:"; splitlines(traceback)];
+            % Remove empty lines
+            lines = lines(strlength(strip(lines)) > 0);
+
+            if options.splitlines
+                for line = lines'
+                    obj.error(line);
                 end
+            else
+                obj.error(join(lines, newline));
             end
         end
     end

--- a/+mlog/StreamHandler.m
+++ b/+mlog/StreamHandler.m
@@ -1,7 +1,7 @@
 classdef StreamHandler < mlog.LogHandler
     %STREAMHANDLER Summary of this class goes here
     %   Detailed explanation goes here
-      
+
     methods
         function writeMessage(~, msgStr)
             fprintf(1, msgStr + "\n");

--- a/+mlog/logging.m
+++ b/+mlog/logging.m
@@ -9,7 +9,7 @@ classdef logging
         DEFAULTFORMAT = "%(asctime)s - %(name)s - %(level)-7s - %(message)s"
         DEFAULTDATEFORMAT = "yyyy-MM-dd HH:mm:ss.SSS"
     end
-  
+
     methods(Static)
         function basicConfig(options)
             arguments

--- a/test/TestFileHandler.m
+++ b/test/TestFileHandler.m
@@ -59,12 +59,12 @@ classdef TestFileHandler < matlab.unittest.TestCase
             logger.warning("This should be logged");
             logger.info("This should not be logged");
             logger.error("This definitely should be logged");
-         
+
             lines = string(importdata(testCase.filepath));
             testCase.verifyLength(lines, 2);
             testCase.verifySubstring(lines(1), "This should be logged");
             testCase.verifySubstring(lines(2), "This definitely should be logged");
         end
     end
- 
+
 end

--- a/test/TestFormatting.m
+++ b/test/TestFormatting.m
@@ -1,5 +1,5 @@
 classdef TestFormatting < LogFileTestCase
- 
+
     methods(Test)
         % Test methods
 
@@ -60,5 +60,5 @@ classdef TestFormatting < LogFileTestCase
             testCase.verifyNotEqual(logger_b2.parent, logger_a);
         end
     end
- 
+
 end

--- a/test/TestLogger.m
+++ b/test/TestLogger.m
@@ -1,5 +1,5 @@
 classdef TestLogger < LogFileTestCase
- 
+
     methods(Test)
         % Test methods
 
@@ -87,5 +87,5 @@ classdef TestLogger < LogFileTestCase
             testCase.verifyTrue(ismember("ERROR - Throw an exception", lines(1:5)));
         end
     end
- 
+
 end

--- a/test/TestLogger.m
+++ b/test/TestLogger.m
@@ -40,7 +40,7 @@ classdef TestLogger < LogFileTestCase
         function testLoggerLevelFilter(testCase)
             % Test a message at a low level is not logged but a high-level is.
             mlog.logging.basicConfig('logfile', testCase.filepath,...
-                'level', 'WARN', 'format', '%(level)s - %(message)s');
+                'level', 'WARNING', 'format', '%(level)s - %(message)s');
             logger = mlog.logging.getLogger();
             logger.info("This should not be logged");
             logger.warning("This should be logged");
@@ -52,6 +52,39 @@ classdef TestLogger < LogFileTestCase
                 "WARNING - This should be logged",...
                 "ERROR - This definitely should be logged"...
             ]);
+        end
+
+        function testLoggerExceptionMultiline(testCase)
+            mlog.logging.basicConfig('logfile', testCase.filepath, ...
+                'format', '%(level)s - %(message)s');
+            logger = mlog.logging.getLogger();
+            try
+                error("Throw an exception");
+            catch ME
+                logger.exception(ME, "We just caught an exception",...
+                    'splitlines', false);
+            end
+            lines = string(importdata(testCase.filepath));
+            testCase.verifyEqual(lines(1), "ERROR - We just caught an exception");
+            % The error message is in the first few lines of log without the
+            % level.
+            testCase.verifyTrue(ismember("Throw an exception", lines(1:5)));
+        end
+
+        function testLoggerExceptionSplitlines(testCase)
+            mlog.logging.basicConfig('logfile', testCase.filepath, ...
+                'format', '%(level)s - %(message)s');
+            logger = mlog.logging.getLogger();
+            try
+                error("Throw an exception");
+            catch ME
+                logger.exception(ME, "We just caught an exception",...
+                    'splitlines', true);
+            end
+            lines = string(importdata(testCase.filepath));
+            testCase.verifyEqual(lines(1), "ERROR - We just caught an exception");
+            % The error message is in the first few lines of log with the level
+            testCase.verifyTrue(ismember("ERROR - Throw an exception", lines(1:5)));
         end
     end
  

--- a/test/TestLogging.m
+++ b/test/TestLogging.m
@@ -1,5 +1,5 @@
 classdef TestLogging < LogFileTestCase
- 
+
     methods(Test)
         % Test methods
 
@@ -20,7 +20,7 @@ classdef TestLogging < LogFileTestCase
             logger = mlog.logging.getLogger();
             logger.info("world");
             logger.close();
-         
+
             testCase.verifyLogfileEqual("INFO: hello world!");
         end
 
@@ -52,5 +52,5 @@ classdef TestLogging < LogFileTestCase
             testCase.verifyNotEqual(logger_b2.parent, logger_a);
         end
     end
- 
+
 end


### PR DESCRIPTION
Log exception traceback using MATLAB fn getReport

Specify whether to split traceback lines over multiple messages.
Includes test. Remove trailing white space.