### PR TITLE
Add documentation, standardise method names, and add stderr

### DIFF
--- a/+mlog/Contents.m
+++ b/+mlog/Contents.m
@@ -1,0 +1,12 @@
+% Customisable logging for your projects.
+% Version 1.0.0 18-Dec-2023 
+%
+% Overview:
+%   logging         - main user interface for creating and customising loggers
+%   Logger          - access point for dispatching logs
+%   LogHandler      - abstract class for formatting and writing logs
+%   StreamHandler   - writing logs to standard output
+%   FileHandler     - writing logs to filesystem
+%   LogLevel        - enumerations of the severity of log
+%
+% See also logging

--- a/+mlog/Contents.m
+++ b/+mlog/Contents.m
@@ -1,12 +1,12 @@
-% Customisable logging for your projects.
-% Version 1.0.0 18-Dec-2023 
+%mlog
+%Version 1.0.0 18-Dec-2023
 %
-% Overview:
-%   logging         - main user interface for creating and customising loggers
-%   Logger          - access point for dispatching logs
-%   LogHandler      - abstract class for formatting and writing logs
-%   StreamHandler   - writing logs to standard output
-%   FileHandler     - writing logs to filesystem
-%   LogLevel        - enumerations of the severity of log
+%Overview:
+%  logging         - main user interface for creating and customising loggers
+%  Logger          - access point for dispatching logs
+%  LogHandler      - abstract class for formatting and writing logs
+%  StreamHandler   - writing logs to IO streams (stdout/stderr)
+%  FileHandler     - writing logs to filesystem
+%  LogLevel        - enumerations of the severity of log
 %
-% See also logging
+%See also logging

--- a/+mlog/FileHandler.m
+++ b/+mlog/FileHandler.m
@@ -6,6 +6,21 @@ classdef FileHandler < mlog.LogHandler
 
     methods
         function obj = FileHandler(filepath, varargin)
+            %FileHandler create a LogHandler which writes to the filesystem.
+            %FileHandler is a subclass of LogHandler.
+            %
+            %  FileHandler(path, __) returns a FileHandler writing to the
+            %  specified filepath in write-only mode by default.
+            %  FileHandler(__, 'filemode', value) opens the file in the desired
+            %  mode.
+            %  FileHandler(__, 'level', value) specifies the minimum threshold
+            %  for the entries being written.
+            %  FileHandler(__, 'format', value) specifies the formatting of
+            %  the logs.
+            %  FileHandler(__, 'dateFormat', value) specifies the formatting of
+            %  datetime fields in the log.
+            %
+            %See also LogHandler, fopen, string.
             parser = inputParser();
             parser.KeepUnmatched = true;
             parser.addRequired('filepath', @mustBeText);

--- a/+mlog/LogHandler.m
+++ b/+mlog/LogHandler.m
@@ -1,6 +1,10 @@
 classdef (Abstract) LogHandler < handle
-    %LOGHANDLER Summary of this class goes here
-    %   Detailed explanation goes here
+    %LOGHANDLER Abstract class which formats LogRecord objects to string and
+    %writes them (abstractly!)
+    %
+    %
+    %
+    %The writeMessage method is customised by derived classes.
 
     properties
         level
@@ -10,6 +14,12 @@ classdef (Abstract) LogHandler < handle
         DEFAULTLEVEL = mlog.LogLevel.ALL
     end
     properties (SetAccess=private)
+        % formatFn format a LogRecord to string according to a specification in
+        % the form "__%(fieldname)s__".
+        %
+        % The field names must occur as properties or methods of LogRecord.
+        %
+        % See also LogRecord.
         formatFn
     end
     properties (Access=private)
@@ -21,6 +31,15 @@ classdef (Abstract) LogHandler < handle
 
     methods
         function obj = LogHandler(options)
+            % LogHandler Create a LogHandler instance.
+            %
+            %  LogHandler(__, 'level', value) specifies the minimum threshold
+            %  for the entries being written. Defaults to ALL.
+            %  LogHandler(__, 'format', value) specifies the formatting of
+            %  the logs.
+            %  See also formatFn.
+            %  LogHandler(__, 'dateFormat', value) specifies the formatting of
+            %  datetime fields in the log.
             arguments
                 options.level (1,1) mlog.LogLevel = mlog.LogHandler.DEFAULTLEVEL
                 options.format (1,1) string = mlog.logging.DEFAULTFORMAT
@@ -32,6 +51,7 @@ classdef (Abstract) LogHandler < handle
         end
 
         function logRecord(obj, record)
+            %logRecord format and write the LogRecord.
             arguments
                 obj
                 record (1,1) mlog.LogRecord
@@ -61,7 +81,6 @@ classdef (Abstract) LogHandler < handle
                 ext = extents{1};
                 matlabFmt = eraseBetween(matlabFmt, ext(1) - 1, ext(2) + 1);
             end
-            % This function will be used to format each message.
             function msgFormatted = formatFn(obj, record)
                 recordFields = cell(length(tokens), 1);
                 for ii = 1:length(tokens)
@@ -79,6 +98,7 @@ classdef (Abstract) LogHandler < handle
     end
 
     methods (Abstract)
+        %writeMessage abstract method to output LogRecord
         writeMessage(msgStr)
     end
 end

--- a/+mlog/LogHandler.m
+++ b/+mlog/LogHandler.m
@@ -31,7 +31,7 @@ classdef (Abstract) LogHandler < handle
             obj.dateFormat = options.dateFormat;
         end
 
-        function logrecord(obj, record)
+        function logRecord(obj, record)
             arguments
                 obj
                 record (1,1) mlog.LogRecord

--- a/+mlog/LogLevel.m
+++ b/+mlog/LogLevel.m
@@ -1,5 +1,7 @@
 classdef LogLevel < uint16
-
+    %LogLevel an enumeration of logging severities.
+    %Each level is associated with a uint16 value and may be ordered by
+    %severity.
     methods
         function obj = LogLevel(value)
             obj@uint16(value)

--- a/+mlog/LogRecord.m
+++ b/+mlog/LogRecord.m
@@ -110,7 +110,7 @@ classdef LogRecord < handle
             res = obj.logger.name;
         end
 
-        function res = get.process(obj)
+        function res = get.process(~)
             res = feature('getpid');
         end
 

--- a/+mlog/Logger.m
+++ b/+mlog/Logger.m
@@ -1,4 +1,18 @@
 classdef Logger < handle
+    %Logger accepts and dispatches messages to be logged by its handlers.
+    %
+    %Messages are filtered by level - only those meeting the minimum threshold
+    %are passed on to its LogHandlers and parent Logger.
+    %A Logger is hierarchical. Each Logger (except the root) has one parent.
+    %The name determines the hierarchy as-per filepaths, but using '.' instead
+    %of slashes.
+    %A Logger has a number (maybe 0) of LogHandler instances. These are
+    %responsible for formatting and writing the logs. A Logger with no
+    %LogHandlers will not record anything.
+    %
+    %Create a Logger using logging.getLogger.
+    %
+    %See also logging, LogHandler.
     properties
         name
         handlers
@@ -15,10 +29,12 @@ classdef Logger < handle
         parent
     end
 
-    %% Constructor
-    % logging class is responsible for creating loggers.
     methods (Access = {?mlog.logging})
         function obj = Logger(name, parent, handlers, level)
+            % Logger create a Logger instance. This can only be done by the
+            % logging module. Use logging.getLogger.
+            %
+            % See also logging
             arguments
                 name (1,1) string
                 parent (1,1)
@@ -90,31 +106,58 @@ classdef Logger < handle
 
         %% Log commands for each level
         function trace(obj, msg, varargin)
+            %trace log a message at level TRACE.
+            %Syntax as-per sprintf.
+            %See also sprintf.
             obj.addMsg(mlog.LogLevel.TRACE, msg, varargin{:});
         end
 
         function debug(obj, msg, varargin)
+            %debug log a message at level DEBUG.
+            %Syntax as-per sprintf.
+            %See also sprintf.
             obj.addMsg(mlog.LogLevel.DEBUG, msg, varargin{:});
         end
 
         function info(obj, msg, varargin)
+            %info log a message at level INFO.
+            %Syntax as-per sprintf.
+            %See also sprintf.
             obj.addMsg(mlog.LogLevel.INFO, msg, varargin{:});
         end
 
         function warning(obj, msg, varargin)
+            %warning log a message at level WARNING.
+            %Syntax as-per sprintf.
+            %See also sprintf.
             obj.addMsg(mlog.LogLevel.WARNING, msg, varargin{:});
         end
 
         function error(obj, msg, varargin)
+            %error log a message at level ERROR.
+            %Syntax as-per sprintf.
+            %See also sprintf.
             obj.addMsg(mlog.LogLevel.ERROR, msg, varargin{:});
         end
 
         function fatal(obj, msg, varargin)
+            %fatal log a message at level FATAL.
+            %Syntax as-per sprintf.
+            %See also sprintf.
             obj.addMsg(mlog.LogLevel.FATAL, msg, varargin{:});
         end
         %%
         function exception(obj, exc, msg, options)
-            % EXCEPTION log the message as an ERROR with the traceback.
+            %EXCEPTION log the message as an ERROR with the traceback.
+            %
+            %  EXCEPTION(exc) logs the provided MException traceback with no
+            %  additional message.
+            %  EXCEPTION(exc, msg) logs the provided MException traceback with
+            %  the message at the start.
+            %  EXCEPTION(__, 'splitlines', true) logs each individual line in
+            %  the traceback with a new log entry. This is useful where an
+            %  automated system requires each line to adhere to the format
+            %  specification.
             arguments
                 obj
                 exc (1,1) MException

--- a/+mlog/Logger.m
+++ b/+mlog/Logger.m
@@ -33,7 +33,7 @@ classdef Logger < handle
     end
     %%
     methods (Access = protected)
-        function addmsg(obj, level, msg, varargin)
+        function addMsg(obj, level, msg, varargin)
             arguments
                 obj
                 level (1,1) mlog.LogLevel
@@ -43,17 +43,17 @@ classdef Logger < handle
                 varargin
             end
             logRecord = mlog.LogRecord(obj, level, msg, varargin{:});
-            obj.propagaterecord(logRecord);
+            obj.propagateRecord(logRecord);
         end
 
-        function propagaterecord(obj, record)
+        function propagateRecord(obj, record)
             if record.level >= obj.level
                 for iHandler = 1:length(obj.handlers)
-                    obj.handlers{iHandler}.logrecord(record);
+                    obj.handlers{iHandler}.logRecord(record);
                 end
                 if ~ismissing(obj.parent)
                     record.logger = obj.parent;
-                    obj.parent.propagaterecord(record);
+                    obj.parent.propagateRecord(record);
                 end
             end
         end
@@ -64,7 +64,7 @@ classdef Logger < handle
             obj.handlers = {};
         end
 
-        function addhandler(obj, handler)
+        function addHandler(obj, handler)
             arguments
                 obj
                 handler (1,1) mlog.LogHandler
@@ -90,27 +90,27 @@ classdef Logger < handle
 
         %% Log commands for each level
         function trace(obj, msg, varargin)
-            obj.addmsg(mlog.LogLevel.TRACE, msg, varargin{:});
+            obj.addMsg(mlog.LogLevel.TRACE, msg, varargin{:});
         end
 
         function debug(obj, msg, varargin)
-            obj.addmsg(mlog.LogLevel.DEBUG, msg, varargin{:});
+            obj.addMsg(mlog.LogLevel.DEBUG, msg, varargin{:});
         end
 
         function info(obj, msg, varargin)
-            obj.addmsg(mlog.LogLevel.INFO, msg, varargin{:});
+            obj.addMsg(mlog.LogLevel.INFO, msg, varargin{:});
         end
 
         function warning(obj, msg, varargin)
-            obj.addmsg(mlog.LogLevel.WARNING, msg, varargin{:});
+            obj.addMsg(mlog.LogLevel.WARNING, msg, varargin{:});
         end
 
         function error(obj, msg, varargin)
-            obj.addmsg(mlog.LogLevel.ERROR, msg, varargin{:});
+            obj.addMsg(mlog.LogLevel.ERROR, msg, varargin{:});
         end
 
         function fatal(obj, msg, varargin)
-            obj.addmsg(mlog.LogLevel.FATAL, msg, varargin{:});
+            obj.addMsg(mlog.LogLevel.FATAL, msg, varargin{:});
         end
         %%
         function exception(obj, exc, msg, options)

--- a/+mlog/StreamHandler.m
+++ b/+mlog/StreamHandler.m
@@ -1,11 +1,46 @@
 classdef StreamHandler < mlog.LogHandler
-    %STREAMHANDLER stream logs to std out.
+    %STREAMHANDLER stream logs to IO streams.
     %
     %See also LogHandler.
 
+    properties(Constant)
+        DEAFULTIOSTREAM = 1
+    end
+    properties
+        streamID
+    end
+
     methods
-        function writeMessage(~, msgStr)
-            fprintf(1, msgStr + "\n");
+        function obj = StreamHandler(varargin)
+            %StreamHandler create a LogHandler which writes to the console (IO
+            %streams). StreamHandler is a subclass of LogHandler.
+            %
+            %  StreamHandler(streamID, __) returns a StreamHandler writing to
+            %  the specified IO stream (1: stdout, 2: stderr). Defaults to
+            %  stdout.
+            %  StreamHandler(__, 'level', value) specifies the minimum
+            %  threshold for the entries being written.
+            %  StreamHandler(__, 'format', value) specifies the formatting of
+            %  the logs.
+            %  StreamHandler(__, 'dateFormat', value) specifies the formatting
+            %  of datetime fields in the log.
+            %
+            %See also LogHandler, string.
+            parser = inputParser();
+            parser.KeepUnmatched = true;
+            parser.addOptional(...
+                'streamID', mlog.StreamHandler.DEAFULTIOSTREAM,...
+                @(x) ismember(x, [1,2])...
+            );
+            parse(parser, varargin{:});
+            unmatched = namedargs2cell(parser.Unmatched);
+
+            obj@mlog.LogHandler(unmatched{:});
+            obj.streamID = parser.Results.streamID;
+        end
+
+        function writeMessage(obj, msgStr)
+            fprintf(obj.streamID, msgStr + newline);
         end
     end
 end

--- a/+mlog/StreamHandler.m
+++ b/+mlog/StreamHandler.m
@@ -1,6 +1,7 @@
 classdef StreamHandler < mlog.LogHandler
-    %STREAMHANDLER Summary of this class goes here
-    %   Detailed explanation goes here
+    %STREAMHANDLER stream logs to std out.
+    %
+    %See also LogHandler.
 
     methods
         function writeMessage(~, msgStr)

--- a/+mlog/logging.m
+++ b/+mlog/logging.m
@@ -21,10 +21,10 @@ classdef logging
             rootLogger = mlog.logging.getLogger();
             rootLogger.level = options.level;
             streamHandler = mlog.StreamHandler('format', options.format);
-            rootLogger.addhandler(streamHandler);
+            rootLogger.addHandler(streamHandler);
             if ~ismissing(options.logfile)
                 fileHandler = mlog.FileHandler(options.logfile, 'format', options.format);
-                rootLogger.addhandler(fileHandler);
+                rootLogger.addHandler(fileHandler);
             end
         end
 

--- a/+mlog/logging.m
+++ b/+mlog/logging.m
@@ -1,6 +1,7 @@
 classdef logging
-    %LOGGING Summary of this class goes here
-    %   Detailed explanation goes here
+    % User access point for logging.
+    % Use getLogger to create or retrieve an existing Logger.
+    % Use basicConfig for simple log configuration.
     properties(Constant, Access=protected)
         loggers = containers.Map
     end
@@ -12,6 +13,14 @@ classdef logging
 
     methods(Static)
         function basicConfig(options)
+            %basicConfig configure the root logger.
+            %A StreamHandler will always be added.  
+            %  basicConfig(__, 'level', value) sets the threshold level for
+            %logging, defaulting to WARNING
+            %  basicConfig(__, 'logfile', value) adds a FileHandler operaring
+            %in write mode, writing to the specified filepath
+            %  basicConfig(__, 'format', value) sets the log format used by the
+            %handlers.
             arguments
                 options.level (1,1) mlog.LogLevel = mlog.logging.DEFAULTLEVEL
                 options.logfile (1,1) string = missing
@@ -23,20 +32,30 @@ classdef logging
             streamHandler = mlog.StreamHandler('format', options.format);
             rootLogger.addHandler(streamHandler);
             if ~ismissing(options.logfile)
-                fileHandler = mlog.FileHandler(options.logfile, 'format', options.format);
+                fileHandler = mlog.FileHandler(options.logfile,...
+                    'format', options.format);
                 rootLogger.addHandler(fileHandler);
             end
         end
 
         function logger = getLogger(name)
-            %GETLOGGER make a new logger or return an existing logger
-            % Return existing logger if one already exists.
+            %getLogger make a new logger or retrieve an existing logger
+            %
+            %  getLogger(name) returns a logger with the desired name.
+            %  getLogger() returns the root logger.
+            %
+            %If the logger already exists then return it, otherwise create a
+            %new one.
+            %The name acts as an ancestry tree, determining a hierarchy of
+            %loggers.
+            %See also Logger.
             arguments
                 name (1,1) string = ""
             end
             loggers = mlog.logging.loggers;
             if isempty(loggers)
-                loggers("") = mlog.Logger("root", missing, [], mlog.logging.DEFAULTLEVEL);
+                loggers("") = mlog.Logger("root", missing, {},...
+                    mlog.logging.DEFAULTLEVEL);
             end
             if ismember(name, keys(loggers))
                 logger = loggers(name);
@@ -71,7 +90,8 @@ classdef logging
             % Every parent must form the start of its child.
             % We may pick up some grand-parents etc. or siblings with different
             % stems.
-            parentFilter = arrayfun(@(p) children.startsWith(p), parents, 'UniformOutput', false);
+            parentFilter = arrayfun(@(p) children.startsWith(p), parents,...
+                'UniformOutput', false);
             parentFilter = cat(2, parentFilter{:});
             % Filter out siblings by checking number of levels.
             % We treat the empty string differently, having 0 levels.

--- a/LoggingExample.m
+++ b/LoggingExample.m
@@ -75,7 +75,7 @@ logger = logging.getLogger();
 display(logger.handlers);
 logger.error("This message won't be seen because there are no handlers");
 handler1 = StreamHandler();
-logger.addhandler(handler1);
+logger.addHandler(handler1);
 logger.error("Now we have a logger we can see the message");
 % We can add another logger with a different format. You can even change how
 % the time is represented.
@@ -83,7 +83,7 @@ logger.error("Now we have a logger we can see the message");
 % logger's level. By default they allow all levels.
 handler2 = StreamHandler('format', '%(asctime)s %(level)s: %(message)s',...
     'dateFormat', 'yyyy MMM dd - HHmmss', 'level', 'ERROR');
-logger.addhandler(handler2);
+logger.addHandler(handler2);
 logger.error("You should see this twice");
 logger.warning("This priority will only be logged by one handler");
 
@@ -117,8 +117,8 @@ daughterLogger.level = LogLevel.ALL;
 display([rootLogger.name fatherLogger.name daughterLogger.name]);
 display([rootLogger.parent fatherLogger.parent.name daughterLogger.parent.name]);
 
-fatherLogger.addhandler(StreamHandler());
-daughterLogger.addhandler(StreamHandler());
+fatherLogger.addHandler(StreamHandler());
+daughterLogger.addHandler(StreamHandler());
 
 % Log different levels to demonstrate the filtering effect of the hierarchy.
 % Notice the logger name in each log message.

--- a/LoggingExample.m
+++ b/LoggingExample.m
@@ -1,0 +1,129 @@
+%% Logging Example
+% Learn how to create and use basic loggers.
+% Your path will need to include the parent folder of +mlog.
+
+%% Section 1a Simplest logger
+% Create a logger, check the level, and then clear up.
+% Configure the logger in the simplest way and then create our logger.
+% The logging class contains the user interaction functions.
+
+% Begin by importing the `mlog.logging` class. Now we can access it using just
+% `logging`.
+import mlog.logging
+
+logging.basicConfig();
+logger = mlog.logging.getLogger();
+fprintf("Log level is %s\n", logger.level);
+logger.error("This should be logged");
+logger.info("This should not be logged");
+% We finish by clearing up the logger using the logging access-point.
+logging.clear();
+% After using `clear` the loggers won't work any more.
+logger.error("The logger has stopped logging.")
+
+%% Section 1b Alternative to importing
+% We can access the logging capability without importing by prefixing
+% references with mlog.
+mlog.logging.basicConfig();
+logger = mlog.logging.getLogger();
+fprintf("Log level is %s\n", logger.level);
+logger.error("This should be logged");
+
+mlog.logging.clear();
+
+%% Section 2a Getting to know basicConfig
+% We can set the level, enable logging to file, and set the log format.
+% After running, check that a local file `example.log` has been created.
+% Notice how the log messages have gone to two different places: the console
+% and a file.
+import mlog.logging
+logging.basicConfig('level', 'INFO', 'logfile', 'example.log');
+logger = logging.getLogger();
+fprintf("Log level is %s\n", logger.level);
+logger.error("This should be logged");
+logger.info("This will now be logged too");
+
+logging.clear();
+
+%% Section 2b Getting to know basicConfig - formatting
+% We can use basicConfig to control the formatting of the logs.
+% There are many fields you can include in the format string. The format string
+% describes the full text that appears in each log - fields, delimiters, and
+% any extra content. The fields must be specified using the form `%(name)s`,
+% where name is the case-sensitive name given to the field in LogRecord, and
+% `s` in this case specifies the string-type formatting. (For numeric fields
+% like line number, change this to `d`).
+% Do not include anything in the form %(name) that isn't a valid field.
+import mlog.logging
+formatStr = '%(asctime)s ~ %(filename)s[%(lineno)d]';
+logging.basicConfig('level', 'INFO', 'format', formatStr);
+logger = logging.getLogger();
+logger.warning("This message is not included");
+
+logging.clear();
+
+%% Section 3 LogHandler
+% In Section 2 we saw that the log messages were sent to two places.
+% This is possible because basicConfig configure the logger to have two
+% `LogHandler`s:a StreamHandler for the console output, and a FileHandler for
+% logging to file.
+% We can set the loggers manually, too.
+import mlog.logging mlog.StreamHandler
+logger = logging.getLogger();
+% Initially there aren't any handlers and so the log messages will not go
+% anywhere.
+display(logger.handlers);
+logger.error("This message won't be seen because there are no handlers");
+handler1 = StreamHandler();
+logger.addhandler(handler1);
+logger.error("Now we have a logger we can see the message");
+% We can add another logger with a different format. You can even change how
+% the time is represented.
+% The handlers have their own log level filter which operate in addition to the
+% logger's level. By default they allow all levels.
+handler2 = StreamHandler('format', '%(asctime)s %(level)s: %(message)s',...
+    'dateFormat', 'yyyy MMM dd - HHmmss', 'level', 'ERROR');
+logger.addhandler(handler2);
+logger.error("You should see this twice");
+logger.warning("This priority will only be logged by one handler");
+
+logging.clear();
+
+%% Section 4 Logging hierarchy
+% We can have several loggers at the same time. A logger may have any number of
+% handlers, including 0.
+% Any logs of sufficient level will be passed to their handlers, and then onto
+% their parent.
+% The hierarchy is determined by the name property, passed to getLogger().
+% If you don't specify a name, the root logger is returned. This is in the
+% ancestry tree of all loggers.
+% Generations of loggers are dot-separated. A name of "some.logger" is the
+% parent to "some.logger.child".
+%
+% We create a hierarchy of loggers with different levels.
+
+import mlog.logging mlog.StreamHandler mlog.LogLevel
+% basicConfig configures the root logger only.
+logging.basicConfig('level', 'WARNING');
+rootLogger = logging.getLogger();
+
+fatherLogger = logging.getLogger('father');
+fatherLogger.level = LogLevel.INFO;
+
+daughterLogger = logging.getLogger('father.daughter');
+daughterLogger.level = LogLevel.ALL;
+
+% Check the names given to the loggers
+display([rootLogger.name fatherLogger.name daughterLogger.name]);
+display([rootLogger.parent fatherLogger.parent.name daughterLogger.parent.name]);
+
+fatherLogger.addhandler(StreamHandler());
+daughterLogger.addhandler(StreamHandler());
+
+% Log different levels to demonstrate the filtering effect of the hierarchy.
+% Notice the logger name in each log message.
+daughterLogger.warning("This message is logged by all loggers");
+daughterLogger.info("This message is logged by only father and daughter");
+daughterLogger.debug("This message is logged by only daughter");
+
+logging.clear();

--- a/test/LogFileTestCase.m
+++ b/test/LogFileTestCase.m
@@ -12,13 +12,13 @@ classdef (Abstract) LogFileTestCase < matlab.unittest.TestCase
 
     methods(TestMethodSetup)
         % Setup for each test
-        function fetchdir(obj)
+        function fetchDir(obj)
             obj.filepath = tempname;
         end
     end
 
     methods(TestMethodTeardown)
-        function cleartempfile(testCase)
+        function clearTempFile(testCase)
             if exist(testCase.filepath, 'file')
                 delete(testCase.filepath);
             end

--- a/test/TestFileHandler.m
+++ b/test/TestFileHandler.m
@@ -1,28 +1,4 @@
-classdef TestFileHandler < matlab.unittest.TestCase
-    properties
-        filepath
-    end
-
-    methods(TestClassSetup)
-        function importPaths(~)
-            addpath(fullfile(fileparts(fileparts(mfilename('fullpath')))));
-        end
-    end
-
-    methods(TestMethodSetup)
-        % Setup for each test
-        function fetchdir(obj)
-            obj.filepath = tempname;
-        end
-    end
-
-    methods(TestMethodTeardown)
-        function cleartempfile(testCase)
-            if exist(testCase.filepath, 'file')
-                delete(testCase.filepath);
-            end
-        end
-    end
+classdef TestFileHandler < LogFileTestCase
 
     methods(Test)
         % Test methods
@@ -54,16 +30,17 @@ classdef TestFileHandler < matlab.unittest.TestCase
         function testLevelFilter(testCase)
             logger = mlog.logging.getLogger();
             logger.level = mlog.LogLevel.ALL;
-            handler = mlog.FileHandler(testCase.filepath, 'level', 'WARN');
-            logger.addhandler(handler);
+            handler = mlog.FileHandler(testCase.filepath, 'level', 'WARN',...
+                'format', '%(message)s');
+            logger.addHandler(handler);
             logger.warning("This should be logged");
             logger.info("This should not be logged");
             logger.error("This definitely should be logged");
 
-            lines = string(importdata(testCase.filepath));
-            testCase.verifyLength(lines, 2);
-            testCase.verifySubstring(lines(1), "This should be logged");
-            testCase.verifySubstring(lines(2), "This definitely should be logged");
+            testCase.verifyLogfileEqual([...
+                "This should be logged";...
+                "This definitely should be logged"...
+            ])
         end
     end
 


### PR DESCRIPTION
User-facing functions and classes have docstrings showing signature.

Method names use camelCase.

StreamHandler can now log to stderr, but defaults to stdout.