### PR TITLE
Allow % symbol escape

### DIFF
--- a/+matlog/FileHandler.m
+++ b/+matlog/FileHandler.m
@@ -2,6 +2,7 @@ classdef FileHandler < matlog.LogHandler
     %FILEHANDLER stream logs to file.
     properties(SetAccess=protected)
         fileID = -1
+        filepath
     end
 
     methods
@@ -30,6 +31,7 @@ classdef FileHandler < matlog.LogHandler
 
             obj@matlog.LogHandler(unmatched{:});
             obj.fileID = fopen(filepath, parser.Results.filemode);
+            obj.filepath = filepath;
         end
 
         function delete(obj)
@@ -37,8 +39,15 @@ classdef FileHandler < matlog.LogHandler
         end
 
         function writeMessage(obj, msgStr)
-            fprintf(obj.fileID, msgStr + newline);
+            % Use format string to directly write our already-formatted message
+            % which allows us to print special symbols like %.
+            fprintf(obj.fileID, '%s\n', msgStr);
         end
     end
 end
 
+function mustBeText(x)
+    if ~(isa(x, 'string') || isa(x, 'char'))
+        error("Value of Data property must be string or char.")
+    end
+end

--- a/+matlog/Logger.m
+++ b/+matlog/Logger.m
@@ -168,7 +168,7 @@ classdef Logger < handle
                 msg (1,1) string = ""
                 options.splitlines (1,1) logical = false
             end
-            traceback = string(exc.getReport());
+            traceback = string(exc.getReport('extended', 'hyperlinks','off'));
             lines = [msg; "Traceback:"; splitlines(traceback)];
             % Remove empty lines
             lines = lines(strlength(strip(lines)) > 0);

--- a/+matlog/StreamHandler.m
+++ b/+matlog/StreamHandler.m
@@ -40,7 +40,9 @@ classdef StreamHandler < matlog.LogHandler
         end
 
         function writeMessage(obj, msgStr)
-            fprintf(obj.streamID, msgStr + newline);
+            % Use format string to directly write our already-formatted message
+            % which allows us to print special symbols like %.
+            fprintf(obj.streamID, '%s\n', msgStr);
         end
     end
 end

--- a/test/TestLogger.m
+++ b/test/TestLogger.m
@@ -86,6 +86,15 @@ classdef TestLogger < LogFileTestCase
             % The error message is in the first few lines of log with the level
             testCase.verifyTrue(ismember("ERROR - Throw an exception", lines(1:5)));
         end
+
+        function testPercentageEscape(testCase)
+            % Test we can log % symbol with %%.
+            matlog.logging.basicConfig('logfile', testCase.filepath, ...
+                'format', '%(message)s');
+            logger = matlog.logging.getLogger();
+            logger.warning('100%% logged');
+            testCase.verifyLogfileEqual("100% logged");
+        end
     end
 
 end


### PR DESCRIPTION
FileHandler and StreamHandler properly print escaped % symbols.

Previously we wrote the message with `fprintf(id, msg)` however this prevents a message with percentage symbols from being printed properly.
Following the formatting of the log message, valid escaped % symbols, i.e. '%%', are converted to '%'. Passing this into fprintf, these are interpreted as attempts for string formatting.
Now, we do `fprintf(id, %s, msg)` which ensures our already-formatted string is pasted in directly without any more attempts at formatting.

Add test for %% escaping.

Also turn off hyperlinks in exception formatting which are not written to file nicely.