### PR TITLE
Add ci.yml instructions for GitHub Actions support.

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,26 @@
+name: Run MATLAB Tests on GitHub-Hosted Runner
+on:
+  # Run on all branches
+  push:
+  # Run manually from Actions tab
+  workflow_dispatch:
+jobs:
+  unittests:
+    name: Run MATLAB Tests and Generate Artifacts
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Run on a variety of releases
+        release: [R2020a, R2021a, R2022a, R2023a]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up MATLAB
+        uses: matlab-actions/setup-matlab@v2
+        with:
+          release: ${{matrix.release}}
+      - name: Run tests and generate artifacts
+        uses: matlab-actions/run-tests@v2
+        with:
+          test-results-junit: test-results/results.xml
+          code-coverage-cobertura: code-coverage/coverage.xml


### PR DESCRIPTION
Tests on 2020a, 2021a, 2022a, 2023a on Linux.
All branches.