### PR TITLE
Update CI to use latest MATLAB releases and github action commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,18 +29,18 @@ jobs:
       
       # Sets up MATLAB on the GitHub Actions runner
       - name: Setup MATLAB
-        uses: matlab-actions/setup-matlab@v1
+        uses: matlab-actions/setup-matlab@v2
         with:
           release: ${{matrix.release}}
 
       # Runs a set of commands using the runners shell
       - name: Run all tests
-        uses: matlab-actions/run-tests@v1
+        uses: matlab-actions/run-tests@v2
         with:
           source-folder: code
 
       # You can use "run-command" to execute custom MATLAB scripts, functions, or statements.
       #- name: Run custom testing procedure
-      #  uses: matlab-actions/run-command@v1
+      #  uses: matlab-actions/run-command@v2
       #  with:
       #    command: disp('Running my custom testing procedure!'); addpath('code'); results = runtests('IncludeSubfolders', true); assertSuccess(results);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       # Sets up MATLAB on the GitHub Actions runner
       - name: Setup MATLAB

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         # Run on a variety of releases
-        release: [R2021a, R2022a, R2023a, R2023b]
+        release: [R2021a, R2022a, R2023a, R2023b, R2024a, R2024b, R2025a]
       # Keep running other releases even if one fails.
       fail-fast: false
 


### PR DESCRIPTION
Add MATLAB R2024a, R2024b, R2025a.

`actions/checkout@v4` -> `actions/checkout@v6`
`actions/run-command@v1` -> `actions/run-command@v2`
`actions/run-command@v1` -> `actions/run-command@v2`